### PR TITLE
Fix typos and add GH Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,43 @@
+name: Build and Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+        env:
+          VITE_APP_ENV: production
+          USE_SUPABASE: 'true'
+          DATABASE_URL: ${{ secrets.SUPABASE_POSTGRES_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_POSTGRES_URL_DEV: ${{ secrets.SUPABASE_POSTGRES_URL }}
+          SUPABASE_POSTGRES_URL_PROD: ${{ secrets.SUPABASE_POSTGRES_URL }}
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist/public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/content/blog/Development-Implications-of-Repeated-Games.md
+++ b/content/blog/Development-Implications-of-Repeated-Games.md
@@ -588,7 +588,7 @@ rise of guilds is likely to have increased N because they made each
 individual member of the guild accountable to the other members of the
 guild. Third, the divisions between urban and rural class could have
 decreased N for individuals in aggregate, decreasing urban dwellers
-interconnectedness with rural dwellers, and vise versa.
+interconnectedness with rural dwellers, and vice versa.
 
 The social structure of Agrarian societies increased ∂ overall because
 stratification decreased the credibility of punishment regimes as well

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -52,7 +52,7 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
+      // always reload the index.html file from disk in case it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(`src="/src/main.tsx"`, `src="/src/main.tsx?v=${nanoid()}"`)
       const page = await vite.transformIndexHtml(url, template);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["client/src/**/*", "db/**/*", "server/**/*"],
+  "include": ["client/src/**/*", "db/**/*", "server/**/*", "types/**/*"],
   "exclude": ["node_modules", "build", "dist"],
   "compilerOptions": {
     "incremental": true,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,2 @@
+declare module 'pg';
+declare module 'nanoid';


### PR DESCRIPTION
## Summary
- fix minor typo in repeated games blog article
- correct typo in server/vite.ts
- include custom type declarations in tsconfig
- add stub module declarations
- add GitHub Pages deployment workflow

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683faf856d0483319a10d0cf37028f68

## Summary by Sourcery

Fix typos, expand TypeScript configuration for custom types, and add a GitHub Pages deployment workflow

Bug Fixes:
- Correct typo in blog article (‘vise’ to ‘vice’)
- Correct typo in server Vite comment (‘incase’ to ‘in case’)

Enhancements:
- Include ‘types’ directory in tsconfig for custom declarations
- Add stub module declarations for ‘pg’ and ‘nanoid’

Deployment:
- Add GitHub Pages build and deployment workflow via GitHub Actions