### PR TITLE
Add release deployment workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Deploy Release to DigitalOcean
+
+on:
+  push:
+    branches: [ release ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          VITE_APP_ENV: production
+          USE_SUPABASE: 'true'
+          DATABASE_URL: ${{ secrets.SUPABASE_POSTGRES_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_POSTGRES_URL_DEV: ${{ secrets.SUPABASE_POSTGRES_URL }}
+          SUPABASE_POSTGRES_URL_PROD: ${{ secrets.SUPABASE_POSTGRES_URL }}
+
+      - name: Deploy to DigitalOcean
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.DIGITALOCEAN_HOST }}
+          username: ${{ secrets.DIGITALOCEAN_USERNAME }}
+          key: ${{ secrets.DIGITALOCEAN_SSH_KEY }}
+          source: "dist/"
+          target: "/var/www/lefv_io"
+          strip_components: 1
+
+      - name: Restart Application
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DIGITALOCEAN_HOST }}
+          username: ${{ secrets.DIGITALOCEAN_USERNAME }}
+          key: ${{ secrets.DIGITALOCEAN_SSH_KEY }}
+          script: |
+            cd /var/www/lefv_io
+            echo "USE_SUPABASE=true" > .env
+            echo "DATABASE_URL=${{ secrets.SUPABASE_POSTGRES_URL }}" >> .env
+            echo "NEXT_PUBLIC_SUPABASE_URL=${{ secrets.SUPABASE_URL }}" >> .env
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" >> .env
+            echo "SUPABASE_POSTGRES_URL_DEV=${{ secrets.SUPABASE_POSTGRES_URL }}" >> .env
+            echo "SUPABASE_POSTGRES_URL_PROD=${{ secrets.SUPABASE_POSTGRES_URL }}" >> .env
+            npm install --production
+            pm2 restart lefv_io || pm2 start npm --name "lefv_io" -- start

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 This project uses GitHub Actions for CI/CD:
 
 - **Continuous Integration**: All pushes and pull requests to the `main` branch trigger linting and tests.
-- **Continuous Deployment**: Successful changes to the `main` branch are automatically deployed to the production server.
+- **Continuous Deployment**: Successful changes to the `release` branch are automatically deployed to the production server.
 
 ### GitHub Actions Workflow
 


### PR DESCRIPTION
## Summary
- deploy changes in `release` branch to DigitalOcean
- mention the new release workflow in the README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840923cf0f08331b0408e60c1476d76

## Summary by Sourcery

Add a GitHub Actions workflow to automatically build and deploy the `release` branch to DigitalOcean and update documentation accordingly

CI:
- Add `release` workflow to GitHub Actions for building and deploying on push to the `release` branch

Deployment:
- Automatically deploy build artifacts to DigitalOcean and restart the application via SSH and pm2 on each `release` branch push

Documentation:
- Update README to reflect continuous deployment from the `release` branch to production