### PR TITLE
fix(blog): bottom card no longer clipped on /blog

### DIFF
--- a/client/src/pages/Blog.tsx
+++ b/client/src/pages/Blog.tsx
@@ -152,7 +152,7 @@ export default function Blog() {
               : "No posts found for the selected tags."}
           </div>
         ) : grouped ? (
-          <div className="space-y-8 pb-6">
+          <div className="space-y-8 pb-24">
             {grouped.map(({ year, posts }) => (
               <section key={year} className="space-y-4">
                 <h2 className="text-xl font-semibold text-muted-foreground border-b pb-1">
@@ -167,7 +167,7 @@ export default function Blog() {
             ))}
           </div>
         ) : (
-          <div className="space-y-4 pb-6">
+          <div className="space-y-4 pb-24">
             {filteredPosts.map((post) => (
               <BlogPost key={post.slug} post={post} />
             ))}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-express",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Bumps `pb-6` → `pb-24` on the scroll container so the last post card has breathing room at viewport bottom. Reproduced visually on lefv.info/blog (Hello World card cut off).

## Summary by Sourcery

Adjust blog page layout spacing and bump package version.

Bug Fixes:
- Prevent the last blog post card from being visually clipped at the bottom of the /blog page by increasing bottom padding of the posts container.

Enhancements:
- Increase vertical padding on blog post lists for both grouped and ungrouped views to provide consistent bottom spacing.

Build:
- Update package.json version from 1.0.0 to 1.1.0.